### PR TITLE
Add Adapter interface first version

### DIFF
--- a/src/interface/Adapter.js
+++ b/src/interface/Adapter.js
@@ -1,0 +1,81 @@
+// @flow
+import type BigNumber from 'bn.js';
+
+import type { ContractData } from './Loader';
+
+export type Address = string;
+
+export type FunctionCall = {
+  method: string,
+  parameters: Array<any>,
+};
+
+export type FunctionCallData = string;
+
+export type GasEstimate = number;
+
+export type SignedTransaction = string;
+
+export type Event = {
+  blockNumber: number,
+  blockHash: string,
+  transactionIndex: number,
+  address: string, // contract address
+  data: string,
+  topics: Array<string>, // topic hashes
+  transactionHash: string,
+  logIndex: number,
+  args: {
+    [paramIndexOrName: number | string]: *,
+    length: number,
+  },
+  event: string, // 'MyEvent'
+  eventSignature: string, // 'MyEvent(uint8)'
+};
+
+export type TransactionReceipt = {
+  blockHash: string,
+  blockNumber: number,
+  contractAddress: string | null,
+  cumulativeGasUsed: BigNumber,
+  gasUsed: BigNumber,
+  hash: string,
+  log: Array<*>,
+  logsBloom: string,
+  root: string,
+  status: number, // 0 => failure, 1 => success
+  transactionHash: string,
+  transactionIndex: number,
+  events: { [String]: Event },
+};
+
+export type FunctionCallResult = { [string | number]: any };
+
+export type SubscriptionOptions = {
+  address?: Address, // defaults to _address
+  event?: string, // all events if omitted
+};
+
+export interface EventEmitter {
+  on(event: string, callback: () => any): void;
+  once(event: string, callback: () => any): void;
+  off(event: string): void;
+}
+
+export type PromiEvent<T> = Promise<T> & EventEmitter;
+
+export interface IAdapter {
+  initialize(contractData: ContractData): void;
+
+  encodeFunctionCall(functionCall: FunctionCall): FunctionCallData;
+  decodeFunctionCallData(functionCallData: FunctionCallData): FunctionCall;
+
+  estimate(functionCall: FunctionCall): Promise<GasEstimate>;
+  sendTransaction(
+    transaction: SignedTransaction,
+  ): PromiEvent<TransactionReceipt>;
+
+  call(functionCall: FunctionCall): Promise<FunctionCallResult>;
+
+  subscribe(options: SubscriptionOptions): Promise<EventEmitter>;
+}


### PR DESCRIPTION
## Description

This PR adds the first version of an Adapter interface. It's expected that our needs for adapters will expand over time as their role becomes more clear, therefore this will probably change!

Types for `Event` and `TransactionReceipt` are taken from [`colony-js-adapter`](https://github.com/JoinColony/colonyJS/tree/master/packages/colony-js-adapter/interface), with `Event` being modified to remove the need for all other types it uses. We may however want to have these here at some point.

Closes #6 
