### PR TITLE
Add helper methods

### DIFF
--- a/integration-testing/index.test.js
+++ b/integration-testing/index.test.js
@@ -32,9 +32,9 @@ describe('Integration testing', () => {
 
   const wallet = new TestWallet(walletAddress, privateKey);
 
-  test('Creating a client', async () => {
+  test('Loading a client', async () => {
     const web3 = new Web3('ws://localhost:8545');
-    client = await Lighthouse.create({
+    client = await Lighthouse.load({
       adapter: {
         name: 'web3',
         options: { web3 },

--- a/src/Lighthouse/__tests__/Lighthouse.test.js
+++ b/src/Lighthouse/__tests__/Lighthouse.test.js
@@ -90,11 +90,11 @@ describe('Lighthouse', () => {
       .mockImplementation(() => ({}));
 
     // no args
-    await Lighthouse.create();
+    await Lighthouse.load();
     expect(Lighthouse.getConstructorArgs).toHaveBeenCalledWith({});
 
     // with args
-    await Lighthouse.create(createArgs);
+    await Lighthouse.load(createArgs);
     expect(Lighthouse.getConstructorArgs).toHaveBeenCalledWith(createArgs);
   });
 
@@ -377,5 +377,22 @@ describe('Lighthouse', () => {
         },
       },
     });
+  });
+
+  test('Defining helpers', () => {
+    const myHelper = sandbox.fn();
+    const helpers = { myHelper, badHelper: true, constructor: sandbox.fn() };
+    sandbox.spyOn(Lighthouse.prototype, '_defineHelpers');
+    sandbox
+      .spyOn(Lighthouse.prototype, '_defineContractInterface')
+      .mockImplementation(() => {});
+
+    const lh = new Lighthouse({ helpers });
+    lh.myHelper();
+
+    expect(lh._defineHelpers).toHaveBeenCalledWith(helpers);
+    expect(myHelper.mock.instances[0]).toBe(lh);
+    expect(lh).not.toHaveProperty('badHelper');
+    expect(lh.constructor).not.toBe(helpers.constructor);
   });
 });

--- a/src/Lighthouse/defaults.js
+++ b/src/Lighthouse/defaults.js
@@ -13,10 +13,10 @@ import Web3Adapter from '../adapters/Web3Adapter';
 import Web3Wallet from '../wallets/Web3Wallet';
 
 // TODO later: JoinColony/lighthouse/issues/16
-export const DEFAULT_LOADER: LoaderName = TruffleParser.name;
+export const DEFAULT_LOADER: LoaderName = TruffleLoader.name;
 
 // TODO later: JoinColony/lighthouse/issues/16
-export const DEFAULT_PARSER: ParserName = TruffleLoader.name;
+export const DEFAULT_PARSER: ParserName = TruffleParser.name;
 
 // TODO later: JoinColony/lighthouse/issues/16
 export const DEFAULT_ADAPTER: AdapterName = Web3Adapter.name;

--- a/src/Lighthouse/flowtypes.js
+++ b/src/Lighthouse/flowtypes.js
@@ -69,6 +69,7 @@ export type LighthouseArgs = {
   methods?: PartialMethodSpecs,
   parser: IParser,
   wallet: IWallet,
+  helpers: Object,
 };
 
 export type {


### PR DESCRIPTION
## Description

Allow helper methods to be passed as extra options when loading, which are then  set at the top level of the Lighthouse instance, after `this` being bound to the instance.

Will disallow setting of helpers with the same name as a property which is already taken on the instance (will not overwrite e.g. `constants`), and in these cases do a `console.warn`.

Although the term "helper" is used here, the user will never actually encounter this, as it was deemed confusing.

## Other changes

* Fix typo in Lighthouse defaults
* Rename `Lighthouse.create` to `.load`

Resolves #59 
