### PR TITLE
Implement Lighthouse.extend({ ... }) method

### DIFF
--- a/src/modules/utils/index.js
+++ b/src/modules/utils/index.js
@@ -2,7 +2,16 @@
 
 import isEmptyHexString from './isEmptyHexString';
 import makeAssert from './makeAssert';
+import mergeOverrides from './mergeOverrides';
+import mergeSpec from './mergeSpec';
 import parseBigNumber from './parseBigNumber';
 import sigHexToRSV from './sigHexToRSV';
 
-export { isEmptyHexString, makeAssert, parseBigNumber, sigHexToRSV };
+export {
+  isEmptyHexString,
+  makeAssert,
+  mergeOverrides,
+  mergeSpec,
+  parseBigNumber,
+  sigHexToRSV,
+};

--- a/src/modules/utils/mergeOverrides.js
+++ b/src/modules/utils/mergeOverrides.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import deepmerge from 'deepmerge';
+
+/**
+ * Merges two partial constant/event/method override objects. Arrays
+ * are merged element by element, or appended if no element already
+ * at index.
+ */
+export default function mergeOverrides(
+  targetOverrides: Object,
+  sourceOverrides: Object,
+) {
+  return deepmerge(targetOverrides, sourceOverrides, {
+    clone: false,
+    arrayMerge: (target: Array<*>, source: Array<*>) =>
+      source.map(
+        (e, i) =>
+          typeof target[i] === 'undefined'
+            ? e
+            : Object.assign({}, target[i], e),
+      ),
+  });
+}

--- a/src/modules/utils/mergeSpec.js
+++ b/src/modules/utils/mergeSpec.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import deepmerge from 'deepmerge';
+
+/**
+ * Merges a partial override object with a full contract spec. Arrays
+ * are merged only if an element exists in the spec at that index.
+ */
+export default function mergeSpec(spec: Object, overrides: Object) {
+  return deepmerge(spec, overrides, {
+    clone: false,
+    arrayMerge: (target: Array<*>, source: Array<*>) =>
+      target.map(
+        (e, i) =>
+          typeof source[i] === 'undefined'
+            ? e
+            : Object.assign({}, e, source[i]),
+      ),
+  });
+}


### PR DESCRIPTION
## Description

Allows defining helper methods and overrides after instantiating Lighthouse.

```js
const lh = Lighthouse.load({ ... })
lh.extend({
  myHelper: () => {},
  constants: {
    myConstant: { ... }
  }
})
```

## Other changes

* Refactor our use of deepmerge into its own Lighthouse utility

Resolves #60 
