### PR TITLE
Various fixes

### DIFF
--- a/src/Tailor/factory.js
+++ b/src/Tailor/factory.js
@@ -15,7 +15,6 @@ import {
 import Adapter from '../adapters/Adapter';
 import Loader from '../loaders/Loader';
 import Parser from '../parsers/Parser';
-import Wallet from '../wallets/Wallet';
 
 import type {
   AdapterName,
@@ -116,7 +115,8 @@ export async function getWallet(
 ): Promise<IWallet> {
   if (!input) throw new Error('Expected a wallet option');
 
-  if (input instanceof Wallet) return Promise.resolve(input);
+  // $FlowFixMe find a better way to check it's a Wallet
+  if (input.sign && input.signMessage) return Promise.resolve(input);
 
   let name: WalletName = '';
   let options;

--- a/src/adapters/Web3Adapter/__tests__/Web3Adapter.test.js
+++ b/src/adapters/Web3Adapter/__tests__/Web3Adapter.test.js
@@ -380,8 +380,12 @@ describe('Web3Adapter', () => {
       mySecond: 'second',
       length: 2,
     };
+    const singleCallResult = 'single value';
 
-    const mockCall = sandbox.fn().mockImplementation(() => callResult);
+    const mockCall = sandbox
+      .fn()
+      .mockImplementationOnce(() => callResult)
+      .mockImplementationOnce(() => singleCallResult);
     const mockMethod = sandbox.fn().mockImplementation(() => ({
       call: mockCall,
     }));
@@ -407,6 +411,10 @@ describe('Web3Adapter', () => {
         }" not defined on this contract`,
       ),
     );
+
+    // single returned value from contract
+    const singleReturnResult = await adapter.call(functionCall);
+    expect(singleReturnResult).toEqual(['single value']);
   });
 
   test('Subscribe', () => {

--- a/src/adapters/Web3Adapter/index.js
+++ b/src/adapters/Web3Adapter/index.js
@@ -209,7 +209,26 @@ export default class Web3Adapter extends Adapter {
       ...args,
     ).call();
 
-    return convertResultObj(args.length, rawResult);
+    // Sometimes only a single value is returned when there is only one
+    // return value on the contract function. Here we convert it to an
+    // object.
+    // TODO: why does this happen? Are we correctly handling a single
+    // array being returned?
+    const resultObject =
+      typeof rawResult !== 'object' ? { '0': rawResult } : rawResult;
+
+    // determine the number of return values from the resultObject
+    let allFound = false;
+    let resultLength = 0;
+    while (!allFound) {
+      if (resultObject[resultLength]) {
+        resultLength += 1;
+      } else {
+        allFound = true;
+      }
+    }
+
+    return convertResultObj(resultLength, resultObject);
   }
 
   subscribe(options: SubscriptionOptions = {}): EventEmitter {

--- a/src/loaders/flowtypes.js
+++ b/src/loaders/flowtypes.js
@@ -32,7 +32,7 @@ export type EtherscanQuery = {
 
 export type EtherscanResponse = {
   status: '0' | '1',
-  result: Array<*>, // The ABI
+  result: string, // ABI JSON string
 };
 
 export type TruffleArtifact = {

--- a/src/loaders/transforms/__tests__/transformEtherscanResponse.test.js
+++ b/src/loaders/transforms/__tests__/transformEtherscanResponse.test.js
@@ -14,6 +14,9 @@ describe('Transforming Etherscan responses', () => {
     expect(() => {
       transformEtherscanResponse('abc', query);
     }).toThrow('Malformed response from Etherscan');
+    expect(() => {
+      transformEtherscanResponse({ status: '1', abi: 'rubbish' }, query);
+    }).toThrow('Error parsing result from Etherscan');
   });
 
   test('Erroneous response', () => {
@@ -33,7 +36,7 @@ describe('Transforming Etherscan responses', () => {
       transformEtherscanResponse(
         {
           status: '1',
-          result: abi,
+          result: JSON.stringify(abi),
         },
         query,
       ),
@@ -47,11 +50,21 @@ describe('Transforming Etherscan responses', () => {
     expect(
       transformEtherscanResponse({
         status: '1',
-        result: abi,
+        result: JSON.stringify(abi),
       }),
     ).toEqual({
       abi,
       address: undefined,
     });
+  });
+
+  test('Getting bytecode errors', () => {
+    expect(
+      () =>
+        transformEtherscanResponse({
+          status: '1',
+          result: JSON.stringify(abi),
+        }).bytecode,
+    ).toThrow('Etherscan does not currently provide contract bytecode');
   });
 });

--- a/src/loaders/transforms/transformEtherscanResponse.js
+++ b/src/loaders/transforms/transformEtherscanResponse.js
@@ -13,13 +13,34 @@ export default function etherscanTransform(
     throw new Error('Malformed response from Etherscan');
   }
 
-  const { result: abi, status } = response;
+  const { result, status } = response;
 
   if (status !== '1')
     throw new Error(`Erroneous response from Etherscan (status: ${status})`);
 
-  return {
+  let abi;
+  try {
+    abi = JSON.parse(result);
+  } catch (error) {
+    throw new Error(`Error parsing result from Etherscan: ${error.toString()}`);
+  }
+
+  const parsed = {
     abi,
     address: query.contractAddress,
+    bytecode: '',
   };
+
+  // Etherscan's API does not return a bytecode property, so we will employ a
+  // custom getter (which throws an error) in order to make this clear.
+  // $FlowFixMe: we don't want to assign a value
+  Object.defineProperty(parsed, 'bytecode', {
+    enumerable: false,
+    configurable: false,
+    get() {
+      throw new Error('Etherscan does not currently provide contract bytecode');
+    },
+  });
+
+  return parsed;
 }

--- a/src/parsers/ABIParser/constants.js
+++ b/src/parsers/ABIParser/constants.js
@@ -17,7 +17,7 @@ export const ADDRESS_PATTERN = /address(\[([0-9]*)])?/;
 
 export const BOOLEAN_PATTERN = /^bool(\[([0-9]*)])*$/;
 
-export const BYTES_PATTERN = /^bytes(([0-9]{1,})(\[([0-9]*)])|(\[([0-9]*)]))*$/;
+export const BYTES_PATTERN = /^bytes([0-9]{1,})(\[([0-9]*)])*$/;
 
 export const BIG_INTEGER_PATTERN = /^u?int([0-9]*)?(\[([0-9]*)])*$/;
 


### PR DESCRIPTION
## Description

- Fix parser bytes type regex
- Update Etherscan loader transform for API changes
- Fix Web3Adapter to account for returned single values
- Fix result length check in Web3Adapter call
- Change factory getWallet to allow Wallets which don't extend Wallet
